### PR TITLE
[qmf-notifications-plugin] Don't emit email_exists for every received…

### DIFF
--- a/src/mailstoreobserver.cpp
+++ b/src/mailstoreobserver.cpp
@@ -327,7 +327,6 @@ void MailStoreObserver::updateNotifications()
         initNotification(notification);
         notification->setAppName(properties.first);
         notification->setAppIcon(properties.second);
-        notification->setHintValue("x-nemo-feedback", "email_exists");
         notification->setHintValue(publishedMessageId, QString::number(messageId.toULongLong()));
         notification->setSummary(message->sender.isEmpty() ? message->origin : message->sender);
         notification->setBody(message->subject);
@@ -376,7 +375,7 @@ void MailStoreObserver::actionsCompleted()
 
                 initNotification(summaryNotification);
                 summaryNotification->setIsTransient(true);
-                summaryNotification->setHintValue("x-nemo-feedback", QStringLiteral("email"));
+                summaryNotification->setHintValue("x-nemo-feedback", QStringLiteral("email_exists"));
 
                 if (newMessages.count() == 1) {
                     const QSharedPointer<MessageInfo> message = newMessages.first();


### PR DESCRIPTION
… email, only for the summary.

The "email_exists" kind of feedback is emiting sound and led pattern as defined in `jolla-common-configurations` private repo  (but not in ngfd repo), while the "email" feedback is not existing. This PR should do the following:
* don't emit feedback for every new email, just publish a notification adding an entry in the event view,
* emit the "email_exists" feedback (sound and led pattern) with the bubble summary notification.

Currently, the following is happening:
* the "email_exists" feedback is emitted for every new email (if you got 12, it is emitted 12 times). These feedback hints are caught by lipstick in the notificationfeedbackplayer, that is stopping the current "email_exists" feedack and restarting it for every hint (ngfd logs in -vvvv mode is filled up with lines like `[1612.18446744073709551183] INFO: dbus: >> stop received for id '1'` immediately followed by `[1612.18446744073709551184] INFO: dbus: >> play received for event 'email_exists' with id '2' (client :1.268 : 2 active request(s))`). Ngfd is kind enough to stop the email ringing and plays only the last one.
* the "email" hint is sent for the summary, but nothinghappens because "email" feedback doesn't exist in `jolla-common-configurations`.

The current PR is highlighting a bug though : the feedback should be a simple "beep" when we are already in the email client (like for the message application), but it is actually ringing full email sound at the moment. With the PR, the full email sound is not emitted anymore (since it was emitted because of the notification hint for each email) but the beep is not working either, because it is using the "email" hint which does not exist in `jolla-common-configurations`.

@pvuorela , what do you think about these changes ? I still can't reproduce the hanging bug in ngfd, but this may be a source of it : maybe when receiving lots of emails, stopping the playback in the gstreamer thread and restarting it repeatedly may be the cause ?