### PR TITLE
[qmf-notifications-plugin] Drop unread notification on device changes.

### DIFF
--- a/src/actionobserver.cpp
+++ b/src/actionobserver.cpp
@@ -207,3 +207,8 @@ void ActionObserver::emptyActionQueue()
         emit actionsCompleted();
     }
 }
+
+bool ActionObserver::hasRunningAction() const
+{
+    return !_runningActions.isEmpty();
+}

--- a/src/actionobserver.h
+++ b/src/actionobserver.h
@@ -76,6 +76,8 @@ class ActionObserver : public QObject
 public:
     explicit ActionObserver(QObject *parent = 0);
 
+    bool hasRunningAction() const;
+
 signals:
     void actionsCompleted();
     void transmitCompleted(const QMailAccountId &accountId);

--- a/src/mailstoreobserver.cpp
+++ b/src/mailstoreobserver.cpp
@@ -466,8 +466,7 @@ void MailStoreObserver::removeMessages(const QMailMessageIdList &ids)
             _publicationChanges = true;
         }
     }
-    // Local action not handled by action observer
-    publishChanges();
+    emit mailStoreChanges();
 }
 
 void MailStoreObserver::removeMessage(const QMailMessageId &id)
@@ -492,6 +491,7 @@ void MailStoreObserver::updateMessages(const QMailMessageIdList &ids)
             }
         }
     }
+    emit mailStoreChanges();
 }
 
 void MailStoreObserver::transmitCompleted(const QMailAccountId &accountId)

--- a/src/mailstoreobserver.h
+++ b/src/mailstoreobserver.h
@@ -62,6 +62,9 @@ class MailStoreObserver : public QObject
 public:
     explicit MailStoreObserver(QObject *parent = 0);
 
+signals:
+    void mailStoreChanges();
+
 public slots:
     void publishChanges();
     void transmitCompleted(const QMailAccountId &accountId);

--- a/src/notificationsplugin.cpp
+++ b/src/notificationsplugin.cpp
@@ -78,6 +78,12 @@ void NotificationsPlugin::exec()
             _mailStoreObserver, &MailStoreObserver::transmitCompleted);
     connect(_actionObserver, &ActionObserver::transmitFailed,
             _mailStoreObserver, &MailStoreObserver::transmitFailed);
+    connect(_mailStoreObserver, &MailStoreObserver::mailStoreChanges,
+            [this] () {
+                if (!_actionObserver->hasRunningAction()) {
+                    _mailStoreObserver->publishChanges();
+                }
+            });
     qMailLog(Messaging) << "Initiating mail notifications plugin";
 }
 


### PR DESCRIPTION
Apply the local metadata changes as soon as
done. In case the associate remote action is
delayed (device is off-line or Internet access
is patchy), the unread notifications may stay
visible while the email has been read locally.
Trigger the actionCompleted slot as soon as
the local storage has been updated.

A way to reproduce the effect is to receive an email then switch off-line. The notification is visible in the event view. Open the email application and open the email. In the application, the email is marked as read, but it is still listed in the event view. With the patch, the read status update is applied as soon as the local storage is updated and not waiting for remote completion to apply the local changes.