### PR TITLE
Small code cleanups. JB#62381 

### DIFF
--- a/rpm/qmf-notifications-plugin.spec
+++ b/rpm/qmf-notifications-plugin.spec
@@ -17,24 +17,6 @@ BuildRequires:  qt5-qttools-linguist
 %description
 %{summary}.
 
-%prep
-%setup -q -n %{name}-%{version}
-
-%build
-
-%qmake5 QMF_INSTALL_ROOT=/usr
-
-make %{?_smp_mflags}
-
-%install
-%qmake5_install
-
-%files
-%defattr(-,root,root,-)
-%license LICENSE.BSD
-%{_libdir}/qt5/plugins/messageserverplugins/libnotifications.so
-%{_datadir}/translations/qmf-notifications_eng_en.qm
-
 %package ts-devel
 Summary:    Translation source for qmf-notifications-plugin
 License:    BSD
@@ -42,6 +24,21 @@ License:    BSD
 %description ts-devel
 %{summary}.
 
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+
+%qmake5 QMF_INSTALL_ROOT=/usr
+%make_build
+
+%install
+%qmake5_install
+
+%files
+%license LICENSE.BSD
+%{_libdir}/qt5/plugins/messageserverplugins/libnotifications.so
+%{_datadir}/translations/qmf-notifications_eng_en.qm
+
 %files ts-devel
-%defattr(-,root,root,-)
 %{_datadir}/translations/source/qmf-notifications.ts

--- a/src/accountscache.cpp
+++ b/src/accountscache.cpp
@@ -37,12 +37,15 @@
 // accounts-qt
 #include <Accounts/Provider>
 
-AccountsCache::AccountsCache(QObject *parent) :
-    QObject(parent)
+AccountsCache::AccountsCache(QObject *parent)
+    : QObject(parent)
 {
-    connect(_manager, SIGNAL(accountCreated(Accounts::AccountId)), this, SLOT(accountCreated(Accounts::AccountId)));
-    connect(_manager, SIGNAL(accountRemoved(Accounts::AccountId)), this, SLOT(accountRemoved(Accounts::AccountId)));
-    connect(_manager, SIGNAL(enabledEvent(Accounts::AccountId)), this, SLOT(enabledEvent(Accounts::AccountId)));
+    connect(_manager, &Accounts::Manager::accountCreated,
+            this, &AccountsCache::accountCreated);
+    connect(_manager, &Accounts::Manager::accountRemoved,
+            this, &AccountsCache::accountRemoved);
+    connect(_manager, &Accounts::Manager::enabledEvent,
+            this, &AccountsCache::enabledEvent);
     initCache();
 }
 
@@ -50,7 +53,7 @@ void AccountsCache::initCache()
 {
     Accounts::AccountIdList accountIDList = _manager->accountListEnabled("e-mail");
 
-    foreach (Accounts::AccountId accountId, accountIDList) {
+    for (Accounts::AccountId accountId : accountIDList) {
         Accounts::Account* account = Accounts::Account::fromId(_manager, accountId, this);
         if (account->enabled()) {
             _accountsList.insert(accountId, account);

--- a/src/accountscache.h
+++ b/src/accountscache.h
@@ -38,6 +38,8 @@
 // accounts-qt
 #include <Accounts/Manager>
 #include <Accounts/Account>
+
+// qmf
 #include <ssoaccountmanager.h>
 
 // Qt

--- a/src/mailstoreobserver.h
+++ b/src/mailstoreobserver.h
@@ -60,17 +60,17 @@ class MailStoreObserver : public QObject
 {
     Q_OBJECT
 public:
-    enum { MaxNotificationsPerAccount = 100 };
-
     explicit MailStoreObserver(QObject *parent = 0);
 
+public slots:
+    void publishChanges();
+    void transmitCompleted(const QMailAccountId &accountId);
+    void transmitFailed(const QMailAccountId &accountId);
+
 private slots:
-    void actionsCompleted();
     void addMessages(const QMailMessageIdList &ids);
     void removeMessages(const QMailMessageIdList &ids);
     void updateMessages(const QMailMessageIdList &ids);
-    void transmitCompleted(const QMailAccountId &accountId);
-    void transmitFailed(const QMailAccountId &accountId);
     void setNotifyOn();
     void setNotifyOff();
     void combinedInboxDisplayed();
@@ -92,8 +92,7 @@ private:
     void notificationClosed(uint reason);
     void notificationActionInvoked(const QString &name);
     QSharedPointer<MessageInfo> constructMessageInfo(const QMailMessageMetaData &message);
-    bool notifyMessage(const QMailMessageMetaData &message);
-    void notifyOnly();
+    bool shouldNotify(const QMailMessageMetaData &message);
     void updateNotifications();
     void clearFoldersToSync();
     bool messageInFolderToSync(const QMailMessageMetaData &message);

--- a/src/notificationsplugin.cpp
+++ b/src/notificationsplugin.cpp
@@ -72,12 +72,12 @@ void NotificationsPlugin::exec()
     // Connect actions observer to mail store observer
     // to report when all actions are completed and
     // only then emit notifications.
-    connect(_actionObserver, SIGNAL(actionsCompleted()),
-            _mailStoreObserver, SLOT(actionsCompleted()));
-    connect(_actionObserver, SIGNAL(transmitCompleted(QMailAccountId)),
-            _mailStoreObserver, SLOT(transmitCompleted(QMailAccountId)));
-    connect(_actionObserver, SIGNAL(transmitFailed(QMailAccountId)),
-            _mailStoreObserver, SLOT(transmitFailed(QMailAccountId)));
+    connect(_actionObserver, &ActionObserver::actionsCompleted,
+            _mailStoreObserver, &MailStoreObserver::publishChanges);
+    connect(_actionObserver, &ActionObserver::transmitCompleted,
+            _mailStoreObserver, &MailStoreObserver::transmitCompleted);
+    connect(_actionObserver, &ActionObserver::transmitFailed,
+            _mailStoreObserver, &MailStoreObserver::transmitFailed);
     qMailLog(Messaging) << "Initiating mail notifications plugin";
 }
 


### PR DESCRIPTION
@dcaliste this as related to details I noticed while checking your PR. The actionsCompleted name got changes, sorry for that, but should be a simple naming change, or then maybe we should make the publishing internal and action tracker to push state for both actions existing or not (like now it's only notifying actionsCompleted but not actions ongoing).