### PR TITLE
[qmf-notifications-plugin] Drop SSOAccountManager.

### DIFF
--- a/src/accountscache.h
+++ b/src/accountscache.h
@@ -39,12 +39,10 @@
 #include <Accounts/Manager>
 #include <Accounts/Account>
 
-// qmf
-#include <ssoaccountmanager.h>
-
 // Qt
 #include <QObject>
 #include <QUrl>
+#include <QSharedPointer>
 #include <QDebug>
 
 struct AccountInfo
@@ -69,7 +67,7 @@ private slots:
 private:
     void initCache();
     bool isEnabledMailAccount(const Accounts::AccountId accountId);
-    SSOAccountManager _manager;
+    QSharedPointer<Accounts::Manager> _manager;
     QHash<Accounts::AccountId, Accounts::Account*> _accountsList;
 };
 


### PR DESCRIPTION
Directly use Accounts::Manager instead of the wrapper introduced by patched QMF for QtAccount integration.

After this patch being done, I'm wondering if the proper fix for this would be to use QMailAccount instead. Indeed, the QtAccount backend in QMF is a patch from Sailfish OS, making this notification plugin dependant on this patch, while ideally it should provide notification independantly of the account backend. Using the QMailStore as the manager, one can get notified of account changes. The Sailfish patch is providing the QtAccount integration, and it already forwards the Accounts::Manager notifications to the QMailStore, as far as I remember.

Maybe this simple patch can be a first step not to propagate too much patched API from QMF, and then, I can try to see if it's possible with the current QtAccount patch to QMailStore and QMailAccount to reproduce the current behaviour with upstream QMF API  only. @pvuorela, what do you think ?