### PR TITLE
[qmf-notifications-plugin] Avoid playing multiple email tones. JB#62613

### DIFF
--- a/src/mailstoreobserver.cpp
+++ b/src/mailstoreobserver.cpp
@@ -301,6 +301,8 @@ void MailStoreObserver::updateNotifications()
 
     // Update the notification for each current message that has been modified
     MessageHash::const_iterator it = _publishedMessages.constBegin(), end = _publishedMessages.constEnd();
+    bool feedbackSet = false;
+
     for ( ; it != end; ++it) {
         const QMailMessageId messageId(it.key());
         const MessageInfo *message(it.value().data());
@@ -321,7 +323,11 @@ void MailStoreObserver::updateNotifications()
         initNotification(notification);
         notification->setAppName(properties.first);
         notification->setAppIcon(properties.second);
-        notification->setHintValue("x-nemo-feedback", "email_exists");
+        if (!feedbackSet) {
+            feedbackSet = true;
+            // just set this once to ensure we don't play multiple tones etc
+            notification->setHintValue("x-nemo-feedback", "email_exists");
+        }
         notification->setHintValue(publishedMessageId, QString::number(messageId.toULongLong()));
         notification->setSummary(message->sender.isEmpty() ? message->origin : message->sender);
         notification->setBody(message->subject);


### PR DESCRIPTION
The feedbacks are messed up with email vs email_exists, latter having sounds set etc.

Those should be cleaned up, but for quick fix for avoiding multiple email tones played at the same time we could just ensure the feedback is set once per set. Even if the feedback declarations would be more sane, we might not want tones played for each separate email in case there are some 50 of them.

@dcaliste maybe something like this for small fix, ref: https://github.com/sailfishos/qmf-notifications-plugin/pull/2 